### PR TITLE
[ocrmypdf-auto] Migrate to Docker Hub

### DIFF
--- a/cmccambridge/ocrmypdf-auto.xml
+++ b/cmccambridge/ocrmypdf-auto.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>ocrmypdf-auto</Name>
-  <Repository>quay.io/cmccambridge/ocrmypdf-auto</Repository>
-  <Registry>https://quay.io/repository/cmccambridge/ocrmypdf-auto</Registry>
+  <Repository>cmccambridge/ocrmypdf-auto:latest</Repository>
+  <Registry>https://hub.docker.com/r/cmccambridge/ocrmypdf-auto</Registry>
   <Network>bridge</Network>
   <MyIP/>
   <Privileged>false</Privileged>


### PR DESCRIPTION
Unraid really doesn't play well with anything but Docker Hub. Migrating back.