### PR TITLE
Add --user flag to use 99/100

### DIFF
--- a/cmccambridge/mosquitto-unraid.xml
+++ b/cmccambridge/mosquitto-unraid.xml
@@ -25,7 +25,7 @@
   <WebUI/>
   <TemplateURL>https://raw.githubusercontent.com/cmccambridge/unraid-templates/master/cmccambridge/mosquitto-unraid.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/cmccambridge/mosquitto-unraid/master/media/eclipse-mosquitto.png</Icon>
-  <ExtraParams/>
+  <ExtraParams>--user=99:100</ExtraParams>
   <PostArgs/>
   <CPUset/>
   <DateInstalled>1541646811</DateInstalled>


### PR DESCRIPTION
Eliminates any issues with file owner and permission issues with logs, password files and reading TLS certificates/keys.